### PR TITLE
Disable Proserver overrides for php.ini options

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -13,7 +13,17 @@ php:
     # If enabled, Ansible will disable Xdebug and provide the command "xdebug",
     # which can be used to enable/disable Xdebug when desired.
     disable_by_default: no
-  php.ini: {}
+  php.ini: >-
+    {%- if ansible_system == 'FreeBSD' -%}
+      expose_php: 'Off'
+      max_execution_time: '240'
+      max_input_vars: '1500'
+      memory_limit: '512M'
+      post_max_size: '50M'
+      upload_max_filesize: '50M'
+      date.timezone: 'Europe/Berlin'
+      mail.add_x_header: 'On'
+    {%- endif -%}
   fpm:
     service: >-
       {%- if ansible_distribution == 'Ubuntu' -%}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -21,14 +21,7 @@ php:
     disable_by_default: no
   php.ini: >-
     {%- if ansible_system == 'FreeBSD' -%}
-      expose_php: 'Off'
-      max_execution_time: '240'
-      max_input_vars: '1500'
-      memory_limit: '512M'
-      post_max_size: '50M'
-      upload_max_filesize: '50M'
-      date.timezone: 'Europe/Berlin'
-      mail.add_x_header: 'On'
+      { expose_php: 'Off', max_execution_time: '240', max_input_vars: '1500', memory_limit: '512M', post_max_size: '50M', upload_max_filesize: '50M', date.timezone: 'Europe/Berlin', mail.add_x_header: 'On'}
     {%- endif -%}
   fpm:
     service: >-

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -20,9 +20,11 @@ php:
     # which can be used to enable/disable Xdebug when desired.
     disable_by_default: no
   php.ini: >-
-    {%- if ansible_system == 'FreeBSD' -%}
-      { expose_php: 'Off', max_execution_time: '240', max_input_vars: '1500', memory_limit: '512M', post_max_size: '50M', upload_max_filesize: '50M', date.timezone: 'Europe/Berlin', mail.add_x_header: 'On'}
-    {%- endif -%}
+    {%- set config_overrides = {} -%}
+      {%- if ansible_system == 'FreeBSD' -%}
+        {%- set _ = user_authorized_key_list.update({{ php_proserver_overrides}}) -%}
+      {%- endif -%}
+    {{- config_overrides -}}
   fpm:
     service: >-
       {%- if ansible_distribution == 'Ubuntu' -%}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -19,12 +19,7 @@ php:
     # If enabled, Ansible will disable Xdebug and provide the command "xdebug",
     # which can be used to enable/disable Xdebug when desired.
     disable_by_default: no
-  php.ini: >-
-    {%- set config_overrides = {} -%}
-      {%- if ansible_system == 'FreeBSD' -%}
-        {%- set _ = user_authorized_key_list.update({{ php_proserver_overrides}}) -%}
-      {%- endif -%}
-    {{- config_overrides -}}
+  php.ini: {}
   fpm:
     service: >-
       {%- if ansible_distribution == 'Ubuntu' -%}

--- a/tasks/php.yaml
+++ b/tasks/php.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Check if the proserver overrides file exists
-  register: aaa-proserver
+  register: aaa_proserver
   stat:
     path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
 
 - name: Disable the Proserver-specific PHP overrides 
-  when: aaa-proserver.stat.exists
+  when: aaa_proserver.stat.exists
   replace:
     path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
     regexp: '^([^;].*)$'

--- a/tasks/php.yaml
+++ b/tasks/php.yaml
@@ -1,4 +1,17 @@
 ---
+- name: Check if the proserver overrides file exists
+  register: aaa-proserver
+  stat:
+    path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
+
+- name: Disable the Proserver-specific PHP overrides 
+  when: aaa-proserver.stat.exists
+  replace:
+    path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
+    regexp: '^([^;].*)$'
+    replace: '; \1'
+  notify: Restart PHP-FPM
+
 - name: Update PHP configuration
   ini_file:
     path: "{{ php_ini }}"

--- a/tasks/php.yaml
+++ b/tasks/php.yaml
@@ -1,15 +1,19 @@
 ---
-- name: Check if the proserver overrides file exists
-  register: aaa_proserver
-  stat:
+- name: Template the overrides file
+  ini_file:
     path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
-
-- name: Disable the Proserver-specific PHP overrides 
-  when: aaa_proserver.stat.exists
-  replace:
-    path: "{{ php.prefix.config }}/php/AAA-01-proserver.ini"
-    regexp: '^([^;].*)$'
-    replace: '; \1'
+    create: no
+    section: null
+    option: "{{ key }}"
+    value: "{{ value }}"
+    state: "{{ 'absent' if key is in php['php.ini'] else 'present' }}"
+  loop_control:
+    label: "{{ key }}={{ value }}"
+  vars:
+    key: "{{ item.0 }}"
+    value: "{{ item.1 }}"
+  loop: "{{ php_proserver_overrides | items() }}"
+  when: "ansible_system == 'FreeBSD'"
   notify: Restart PHP-FPM
 
 - name: Update PHP configuration

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,10 @@
+---
+php_proserver_overrides:
+  expose_php: 'Off'
+  max_execution_time: '240'
+  max_input_vars: '1500'
+  memory_limit: '512M'
+  post_max_size: '50M'
+  upload_max_filesize: '50M'
+  date.timezone: 'Europe/Berlin'
+  mail.add_x_header: 'On'


### PR DESCRIPTION
Will check if an option exists in the php['php.ini'] hash and disable its respective override in /usr/local/etc/php/AAA-01-proserver.ini